### PR TITLE
Aleris DIL integration test - changes

### DIFF
--- a/aleris/dil/config/aleris_dil.xml
+++ b/aleris/dil/config/aleris_dil.xml
@@ -20,10 +20,7 @@
                         <step>
                             <id>3</id>
                             <type>action</type>
-                            <uri>aleris</uri>
-                            <options>
-                                <id>46689a90-d0f8-11ec-83f5-3747809ef661</id>
-                            </options>
+                            <uri>aleris:myid</uri>
                         </step>
                         <step>
                             <id>4</id>


### PR DESCRIPTION
Removed `id` parameter, and used `path` instead